### PR TITLE
Ignore php-actions/phpunit >= 5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       day: "friday"
     ignore:
       - dependency-name: "php-actions/phpunit"
-        versions: ['>= 7']
+        versions: ['>= 5']
 
   # Maintain dependencies for npm/yarn
   - package-ecosystem: "npm"


### PR DESCRIPTION
There are two more [version branches](https://github.com/php-actions/phpunit/branches/stale) (not tags) that need to be ignored.