### PR TITLE
Use SMTP for Sendgrid

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,14 +54,13 @@ jobs:
           DOTENV_DB_USERNAME: "${{ vars.DB_USERNAME }}"
           DOTENV_DB_PASSWORD: "${{ secrets.DB_PASSWORD }}"
 
-          DOTENV_MAIL_MAILER: "sendgrid"
+          DOTENV_MAIL_MAILER: "smtp/sendgrid"
+          DOTENV_MAIL_HOST: smtp.sendgrid.net
+          DOTENV_MAIL_PORT: 465
+          DOTENV_MAIL_ENCRYPTION: ssl
+          DOTENV_MAIL_USERNAME: apikey
+          DOTENV_MAIL_PASSWORD: "${{ secrets.SENDGRID_API_KEY }}"
           DOTENV_SENDGRID_API_KEY: "${{ secrets.SENDGRID_API_KEY }}"
-
-          # DOTENV_MAIL_HOST: ${{ vars.MAIL_HOST }}
-          # DOTENV_MAIL_PORT: ${{ vars.MAIL_PORT }}
-          # DOTENV_MAIL_USERNAME: "${{ vars.MAIL_USERNAME }}"
-          # DOTENV_MAIL_PASSWORD: "${{ secrets.MAIL_PASSWORD }}"
-          # DOTENV_MAIL_ENCRYPTION: ${{ vars.MAIL_ENCRYPTION }}
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/config/mail.php
+++ b/config/mail.php
@@ -36,6 +36,15 @@ return [
 
     'mailers' => [
 
+        'smtp/sendgrid' => [
+            'transport' => 'failover',
+            'mailers' => [
+                'smtp',
+                'sendgrid',
+                'log',
+            ],
+        ],
+
         'smtp' => [
             'transport' => 'smtp',
             'url' => env('MAIL_URL'),


### PR DESCRIPTION
The [symfony/sendgrid-mailer](https://github.com/symfony/sendgrid-mailer) silently drops the `method` from the ics attachments which means that some clients do not show an invitation widget. I am hoping that using SMTP will retain this information.