### PR TITLE
Formally make all events OPAQUE

### DIFF
--- a/app/iCal/Domain/Entity/Event.php
+++ b/app/iCal/Domain/Entity/Event.php
@@ -3,6 +3,7 @@
 namespace App\iCal\Domain\Entity;
 
 use App\iCal\Domain\Enum\Classification;
+use App\iCal\Domain\Enum\Transparency;
 use App\iCal\Domain\ValueObject\Sequence;
 use Eluceo\iCal\Domain\Entity\Event as EluceoEvent;
 use Eluceo\iCal\Domain\ValueObject\UniqueIdentifier;
@@ -16,6 +17,8 @@ class Event extends EluceoEvent
     private ?string $htmlDescription = null;
 
     private ?Sequence $sequence = null;
+
+    private ?Transparency $transparency = null;
 
     public function __construct(?UniqueIdentifier $uniqueIdentifier = null)
     {
@@ -127,6 +130,30 @@ class Event extends EluceoEvent
     public function unsetSequence(): static
     {
         $this->sequence = null;
+
+        return $this;
+    }
+
+    public function setTransparency(Transparency $transparency): static
+    {
+        $this->transparency = $transparency;
+
+        return $this;
+    }
+
+    public function getTransparency(): Transparency
+    {
+        return $this->transparency;
+    }
+
+    public function hasTransparency(): bool
+    {
+        return $this->transparency !== null;
+    }
+
+    public function unsetTransparency(): static
+    {
+        $this->transparency = null;
 
         return $this;
     }

--- a/app/iCal/Domain/Enum/Transparency.php
+++ b/app/iCal/Domain/Enum/Transparency.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\iCal\Domain\Enum;
+
+enum Transparency
+{
+    case Opaque;
+    case Transparent;
+
+    public static function default(): static
+    {
+        return self::Opaque;
+    }
+}

--- a/app/iCal/Presentation/Factory/EventFactory.php
+++ b/app/iCal/Presentation/Factory/EventFactory.php
@@ -13,6 +13,7 @@ namespace App\iCal\Presentation\Factory;
 
 use App\iCal\Domain\Entity\Event;
 use App\iCal\Domain\Enum\Classification;
+use App\iCal\Domain\Enum\Transparency;
 use Eluceo\iCal\Domain\Entity\Event as EluceoEvent;
 use Eluceo\iCal\Presentation\Component;
 use Eluceo\iCal\Presentation\Component\Property;
@@ -40,6 +41,10 @@ class EventFactory extends EluceoEventFactory
                 $component = $component->withProperty(new Property('CLASS', $this->getEventClassificationTextValue($event->getClassification())));
             }
 
+            if ($event->hasTransparency()) {
+                $component = $component->withProperty(new Property('TRANSP', $this->getEventTransparencyTextValue($event->getTransparency())));
+            }
+
             if ($event->hasComment()) {
                 $component = $component->withProperty(new Property('COMMENT', new TextValue($event->getComment())));
             }
@@ -63,6 +68,15 @@ class EventFactory extends EluceoEventFactory
             Classification::Private => 'PRIVATE',
             Classification::Public => 'PUBLIC',
             default => throw new UnexpectedValueException(sprintf('The enum %s resulted in an unknown classification value that is not yet implemented.', Classification::class))
+        });
+    }
+
+    private function getEventTransparencyTextValue(Transparency $transparency): TextValue
+    {
+        return new TextValue(match ($transparency) {
+            Transparency::Opaque => 'OPAQUE',
+            Transparency::Transparent => 'TRANSPARENT',
+            default => throw new UnexpectedValueException(sprintf('The enum %s resulted in an unknown transparency value that is not yet implemented.', Transparency::class))
         });
     }
 }

--- a/resources/views/booking/ics.php
+++ b/resources/views/booking/ics.php
@@ -6,6 +6,7 @@ use App\iCal\Domain\Entity\Calendar;
 use App\iCal\Domain\Entity\Event;
 use App\iCal\Domain\Enum\CalendarMethod;
 use App\iCal\Domain\Enum\Classification;
+use App\iCal\Domain\Enum\Transparency;
 use App\iCal\Domain\ValueObject\Sequence;
 use App\iCal\Presentation\Factory\CalendarFactory;
 use App\iCal\Presentation\Factory\EventFactory;
@@ -96,7 +97,8 @@ foreach ($bookings as $booking) {
     $event
         ->setClassification(Classification::Private)
         ->setHtmlDescription($htmlDescription, $textDescription)
-        ->setSequence(new Sequence($booking->sequence));
+        ->setSequence(new Sequence($booking->sequence))
+        ->setTransparency(Transparency::Opaque);
     $event
         ->setOccurrence(
             new TimeSpan(

--- a/tests/Unit/iCal/Domain/Entity/EventTest.php
+++ b/tests/Unit/iCal/Domain/Entity/EventTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\iCal\Domain\Entity;
 
 use App\iCal\Domain\Entity\Event;
 use App\iCal\Domain\Enum\Classification;
+use App\iCal\Domain\Enum\Transparency;
 use Tests\TestCase;
 use TypeError;
 
@@ -142,5 +143,42 @@ class EventTest extends TestCase
         $this->assertFalse($event->hasHtmlDescription());
         $this->assertEquals($text, $event->getDescription());
         $this->assertTrue($event->hasDescription());
+    }
+
+    public function test_set_get_transparency(): void
+    {
+        $transparency = fake()->randomElement(Transparency::class);
+
+        $event = new Event;
+        // setClassification is chainable
+        $this->assertEquals($event, $event->setTransparency($transparency));
+        // hasClassification is true when any Classification is set
+        $this->assertTrue($event->hasTransparency());
+        // getClassification returns the set classification
+        $this->assertEquals($transparency, $event->getTransparency());
+    }
+
+    public function test_get_transparency_fails_with_no_transparency(): void
+    {
+        $this->expectException(TypeError::class);
+
+        $event = new Event;
+        $event->getTransparency();
+    }
+
+    public function test_has_transparency_with_no_transparency(): void
+    {
+        $event = new Event;
+        $this->assertFalse($event->hasTransparency());
+    }
+
+    public function test_unset_transparency(): void
+    {
+        $transparency = fake()->randomElement(Transparency::class);
+
+        $event = new Event;
+        $event->setTransparency($transparency);
+        $this->assertEquals($event, $event->unsetTransparency());
+        $this->assertFalse($event->hasTransparency());
     }
 }

--- a/tests/Unit/iCal/Presentation/Factory/EventFactoryTest.php
+++ b/tests/Unit/iCal/Presentation/Factory/EventFactoryTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\iCal\Presentation\Factory;
 
 use App\iCal\Domain\Entity\Event;
 use App\iCal\Domain\Enum\Classification;
+use App\iCal\Domain\Enum\Transparency;
 use App\iCal\Presentation\Factory\EventFactory;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
@@ -57,5 +58,25 @@ class EventFactoryTest extends TestCase
 
         $this->assertStringContainsString('X-ALT-DESC;FMTTYPE=text/html:', (string) $output);
         $this->assertStringContainsString('DESCRIPTION:', (string) $output);
+    }
+
+    #[DataProvider('transparency_output_provider')]
+    public function test_transparency_is_rendered(Transparency $transparency, string $expected): void
+    {
+        $event = new Event();
+        $event->setTransparency($transparency);
+
+        $factory = new EventFactory();
+        $output = $factory->createComponent($event);
+
+        $this->assertStringContainsString("TRANSP:$expected\r\n", (string) $output);
+    }
+
+    public static function transparency_output_provider(): array
+    {
+        return [
+            [Transparency::Opaque, 'OPAQUE'],
+            [Transparency::Transparent, 'TRANSPARENT'],
+        ];
     }
 }


### PR DESCRIPTION
I don't know if this is useful; if `TRANSP` is not present then it is considered to be `OPAQUE` anyway.