### PR TITLE
Fix create and update user forms

### DIFF
--- a/app/Casts/AsUniqueEnumCollection.php
+++ b/app/Casts/AsUniqueEnumCollection.php
@@ -40,7 +40,7 @@ class AsUniqueEnumCollection implements Castable
             public function get($model, $key, $value, $attributes): ?Collection
             {
                 if (! isset($attributes[$key])) {
-                    return null;
+                    return collect([]);
                 }
                 if (empty($attributes[$key])) {
                     return collect([]);

--- a/resources/views/user/create.blade.php
+++ b/resources/views/user/create.blade.php
@@ -19,7 +19,7 @@
                 'timezone' => old('timezone', $user->timezone?->getName()),
                 'section' => old('section', $user->section),
                 'role' => old('role', $user->role),
-                'accreditations' => old('accreditations', $user->accreditations->all()),
+                'accreditations' => old('accreditations', $user->accreditations->pluck('value')->all()),
             ]) }},
             init() {
                 $nextTick(() => {

--- a/resources/views/user/edit.blade.php
+++ b/resources/views/user/edit.blade.php
@@ -13,7 +13,7 @@
             'timezone' => old('timezone', $user->timezone?->getName()),
             'section' => old('section', $user->section),
             'role' => old('role', $user->role),
-            'accreditations' => old('accreditations', $user->accreditations->all()),
+            'accreditations' => old('accreditations', $user->accreditations->pluck('value')->all()),
         ]) }},
         init() {
             $nextTick(() => {


### PR DESCRIPTION
- Provides an empty list of accreditations rather than `null` for a new user.
- Provides the form a list of accreditation values, rather than enum objects.