### PR TITLE
Reduce chance of text wrapping breaking a test

### DIFF
--- a/tests/Unit/iCal/Presentation/Factory/TodoFactoryTest.php
+++ b/tests/Unit/iCal/Presentation/Factory/TodoFactoryTest.php
@@ -46,7 +46,7 @@ class TodoFactoryTest extends TestCase
 
     public function test_summary_is_rendered(): void
     {
-        $summary = fake()->sentence();
+        $summary = fake()->sentence(5);
 
         $todo = new Todo;
         $todo->setSummary($summary);
@@ -59,7 +59,7 @@ class TodoFactoryTest extends TestCase
 
     public function test_description_is_rendered(): void
     {
-        $description = fake()->sentence();
+        $description = fake()->sentence(5);
 
         $todo = new Todo;
         $todo->setDescription($description);


### PR DESCRIPTION
Sometimes the sentence generated causes the line to wrap, and then these tests can fail. Using 5 words (±40% = 7) instead of 6 words (±40% = 9) should reduce the chance of breaking tests.